### PR TITLE
Add missed initialization of spike count

### DIFF
--- a/eval/iq-neuron/include/iq_neuron.h
+++ b/eval/iq-neuron/include/iq_neuron.h
@@ -25,7 +25,7 @@ public:
 private:
     int t_neuron;                                   // Iterator of timestep
     int _rest, _threshold, _a, _b, _reset, _noise;  // IQ neuron parameters
-    int x , f_min, _spike_count;
+    int x , f_min, _spike_count = 0;
     bool _is_set = false, _is_firing = false;
 };
 

--- a/eval/iq-neuron/include/iz_neuron.h
+++ b/eval/iq-neuron/include/iz_neuron.h
@@ -29,7 +29,7 @@ private:
     float _k, _rest, _threshold;
     int _noise;
     const float VMAX = 255;
-    int _spike_count;
+    int _spike_count = 0;
     bool _is_set = false, _is_firing = false;
 };
 


### PR DESCRIPTION
As discussed in the [issue page of origin iq-neuron repo](https://github.com/twetto/iq-neuron/issues/1).