### PR TITLE
Fix memory leak & improving performance

### DIFF
--- a/eval/iq-neuron/include/iq_network.h
+++ b/eval/iq-neuron/include/iq_network.h
@@ -1,10 +1,10 @@
+/* IQIF network
+ * Chen-Fu Yeh, 2019/11/09
+ */
+
 #ifndef IQ_NETWORK_H
 #define IQ_NETWORK_H
 #include "iq_neuron.h"
-#include <stdio.h>
-#include <stdlib.h>
-#include <random>
-#include <time.h>
 #include <math.h>
 #include <omp.h>
 
@@ -13,25 +13,27 @@ class iq_network
 public:
     iq_network();
     ~iq_network();
-    int set_neurons();
-    int get_weight();
     int num_neurons();
-    void send_synapse();
-    void printfile(FILE **fp);
+    void send_synapse();                    // proceed one timestep
+    void printfile(FILE **fp);              // output potentials
     void set_biascurrent(int neuron_index, int biascurrent);
     int potential(int neuron_index);
     int spike_count(int neuron_index);
     float spike_rate(int neuron_index);
-    void set_num_threads(int num_threads);
+    void set_num_threads(int num_threads);  // for multithreading
 
 private:
-    int linenum_neuronParameter();
+    int linenum_neuronParameter();  // get # of neurons by # of lines in file
+    int set_neurons();              // read from input/neuronParameter.txt
+    int get_weight();               // read from input/connectionTable.txt
     int _num_neurons;
-    int *_tau, *_f, *_n;
-    int *_weight, *_scurrent, *_ncurrent, *_biascurrent;
+    int *_tau, *_f, *_n;            // synapse decay time constant & siblings
+    int *_weight;                   // synapse weight matrix
+    int *_scurrent;                 // synapse current matrix
+    int *_ncurrent;                 // neuron input synapse current
+    int *_biascurrent;              // neuron bias current
     iq_neuron *_neurons;
     int _num_threads = 1;
-
 };
 
 #endif

--- a/eval/iq-neuron/include/iq_network.h
+++ b/eval/iq-neuron/include/iq_network.h
@@ -5,6 +5,7 @@
 #ifndef IQ_NETWORK_H
 #define IQ_NETWORK_H
 #include "iq_neuron.h"
+#include "weight_index_list.h"
 #include <math.h>
 #include <omp.h>
 
@@ -33,6 +34,7 @@ private:
     int *_ncurrent;                 // neuron input synapse current
     int *_biascurrent;              // neuron bias current
     iq_neuron *_neurons;
+    weight_index_list *_wlist;      // axon index for each neurons
     int _num_threads = 1;
 };
 

--- a/eval/iq-neuron/include/iq_neuron.h
+++ b/eval/iq-neuron/include/iq_neuron.h
@@ -1,9 +1,11 @@
+/* IQIF neuron object
+ * Chen-Fu Yeh, 2019/11/09
+ */
+
 #ifndef IQ_NEURON_H
 #define IQ_NEURON_H
 #include <stdio.h>
 #include <stdlib.h>
-#include <time.h>
-#include <limits.h>
 
 #define MAX_POTENTIAL 255
 

--- a/eval/iq-neuron/include/iq_neuron.h
+++ b/eval/iq-neuron/include/iq_neuron.h
@@ -9,6 +9,8 @@
 
 #define MAX_POTENTIAL 255
 
+class iq_network;
+
 class iq_neuron
 {
 public:
@@ -23,6 +25,8 @@ public:
     bool is_firing();
     int spike_count();
     float spike_rate();
+
+    friend class iq_network;                // For direct access to _is_firing
 
 private:
     int t_neuron;                                   // Iterator of timestep

--- a/eval/iq-neuron/include/weight_index_list.h
+++ b/eval/iq-neuron/include/weight_index_list.h
@@ -1,0 +1,31 @@
+/* Singly-linked list for axon indexing
+ * Chen-Fu Yeh, 2019/11/09
+ */
+
+#ifndef WEIGHT_INDEX_LIST_H
+#define WEIGHT_INDEX_LIST_H
+#include <stdio.h>
+
+class weight_index_list;
+
+class weight_index_node
+{
+public:
+    weight_index_node(int data);
+    
+    int _data;
+    weight_index_node *_next;
+};
+
+class weight_index_list
+{
+public:
+    weight_index_list();
+    ~weight_index_list();
+    void push_front(int data);
+
+    weight_index_node *_first;
+};
+
+#endif
+

--- a/eval/iq-neuron/src/iq_network.cpp
+++ b/eval/iq-neuron/src/iq_network.cpp
@@ -160,6 +160,7 @@ void iq_network::send_synapse()
                     *(_ncurrent + i) += ncurrent_private[i];
                 }
             }
+            delete[] ncurrent_private;
         }
     }
     else {

--- a/eval/iq-neuron/src/iq_neuron.cpp
+++ b/eval/iq-neuron/src/iq_neuron.cpp
@@ -1,3 +1,7 @@
+/* IQIF neuron object
+ * Chen-Fu Yeh, 2019/11/09
+ */
+
 #include "iq_neuron.h"
 
 using namespace std;
@@ -5,15 +9,15 @@ using namespace std;
 iq_neuron::iq_neuron(int rest, int threshold,
                      int reset, int a, int b, int noise)
 {
-    x = rest;
+    x = rest;                               // initialize with rest potential
     t_neuron = 0;
-    f_min = (a*rest + b*threshold) / (a+b);
+    f_min = (a*rest + b*threshold) / (a+b); // dV/dt and others
     _a = a;
     _b = b;
     _rest = rest;
     _threshold = threshold;
     _reset = reset;
-    if(noise == 0) noise++;
+    if(noise == 0) noise++;                 // set noise strength
     else if(noise < 0) noise = -noise;
     _noise = noise;
     _is_set = true;
@@ -47,12 +51,15 @@ void iq_neuron::iq(int external_current)
 {
     int f;
 
+    /* solving dV/dt */
     if(x < f_min)
         f = _a * (_rest - x);
     else
         f = _b * (x - _threshold);
     x += f/10 + external_current + rand()%_noise-_noise/2;
     _is_firing = false;
+
+    /* fire if exceeding action potential */
     if(x > MAX_POTENTIAL) {
         _spike_count++;
         _is_firing = true;

--- a/eval/iq-neuron/src/iq_neuron.cpp
+++ b/eval/iq-neuron/src/iq_neuron.cpp
@@ -57,9 +57,9 @@ void iq_neuron::iq(int external_current)
     else
         f = _b * (x - _threshold);
     x += f/10 + external_current + rand()%_noise-_noise/2;
-    _is_firing = false;
 
     /* fire if exceeding action potential */
+    _is_firing = false;
     if(x > MAX_POTENTIAL) {
         _spike_count++;
         _is_firing = true;

--- a/eval/iq-neuron/src/weight_index_list.cpp
+++ b/eval/iq-neuron/src/weight_index_list.cpp
@@ -1,0 +1,39 @@
+/* Singly-linked list for axon indexing
+ * Chen-Fu Yeh, 2019/11/09
+ */
+
+#include "weight_index_list.h"
+
+using namespace std;
+
+weight_index_node::weight_index_node(int data)
+{
+    _data = data;
+    _next = NULL;
+    return;
+}
+
+weight_index_list::weight_index_list()
+{
+    _first = NULL;
+    return;
+}
+
+weight_index_list::~weight_index_list()
+{
+    while(_first != NULL) {
+        weight_index_node *current = _first;
+        _first = _first->_next;
+        delete current;
+    }
+    return;
+}
+
+void weight_index_list::push_front(int data)
+{
+    weight_index_node *newNode = new weight_index_node(data);
+    newNode->_next = _first;
+    _first = newNode;
+    return;
+}
+


### PR DESCRIPTION
By using valgrind I realized the OpenMP section in `send_synapse()` had severe memory leak. It was because every `new`-ed `ncurrent_private` was not deleted after the critical section. This had been fixed by adding `delete[] ncurrent_private`.